### PR TITLE
Fix w.u.c.render_to_string with request=None

### DIFF
--- a/wagtail/utils/compat.py
+++ b/wagtail/utils/compat.py
@@ -35,6 +35,6 @@ def render_to_string(template_name, context=None, request=None, **kwargs):
         return loader.render_to_string(
             template_name,
             dictionary=context,
-            context_instance=RequestContext(request),
+            context_instance=RequestContext(request) if request else None,
             **kwargs
         )


### PR DESCRIPTION
When passed `request=None`, `wagtail.utils.compat.render_to_string` would fail as it tried to construct a `RequestContext` without a request.

Now, if `request=None,` no RequestContext is constructed, and no `context_instance` is passed to `render_to_string`.
